### PR TITLE
Fix COMMIT_NUMBER value in swag-deploy

### DIFF
--- a/.github/workflows/maven-swag-deploy.yml
+++ b/.github/workflows/maven-swag-deploy.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v2


### PR DESCRIPTION
Сейчас всегда проставляется единица в версиях:
<img width="508" alt="Screenshot 2022-02-24 at 18 55 37" src="https://user-images.githubusercontent.com/5084395/155559741-5161930d-65d5-4c5f-9fe3-50fbf872c444.png">

