### PR TITLE
Bump ubuntu version for thrift builds

### DIFF
--- a/.github/workflows/maven-thrift-build.yml
+++ b/.github/workflows/maven-thrift-build.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install thrift
         uses: valitydev/action-setup-thrift@v1.0.2

--- a/.github/workflows/maven-thrift-deploy.yml
+++ b/.github/workflows/maven-thrift-deploy.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install thrift
         uses: valitydev/action-setup-thrift@v0.0.6


### PR DESCRIPTION
Пропустили один момент с обновлением трифта на 0.17.0 - при сборке бинарника у нас использовался тег ```ubuntu-latest``` 
[valitydev/thrift/.github/workflows/build-and-upload-binaries-after-release.yaml](https://github.com/valitydev/thrift/blob/75c229b6ddf769a27014814796a66ec3da1870fd/.github/workflows/build-and-upload-binaries-after-release.yaml#L16)
```yaml
      matrix:
        include:
          - platform: Linux x86_64
            os: ubuntu-latest
            artifact-path: compiler/cpp/cmake-build/bin
            asset-name: thrift-${{ github.ref_name }}-linux-amd64.tar.gz
            install-deps: sudo apt update && sudo apt install -yq automake bison flex cmake
```
 - к тому моменту (начало декабря 22 года) гитхаб уже переехал на релиз 22.04, если верить этому посту: https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/

Из-за этого трифт собрался на 22.04, а при сборке протоколов сейчас используется ubuntu-20.04 (
[valitydev/java-workflow/.github/workflows/maven-thrift-build.yml](https://github.com/valitydev/java-workflow/blob/587fd5936bfc85df86dc0d43abc682e46d3f9455/.github/workflows/maven-thrift-build.yml#L19)
```yml

jobs:
  build:
    runs-on: ubuntu-20.04
    steps:
      - name: Install thrift
        uses: valitydev/action-setup-thrift@v1.0.2
```
). В ней более старая версия glibc, из-за чего трифт отказывается стартовать: https://github.com/valitydev/mayday-proto/actions/runs/5013023006/jobs/8985631531. Всё это время его просто никто не использовал похоже (у нас в целом и протоколы новые не пилились) + все сидели на прошлой версии.