### PR TITLE
Bump thrift deploy action

### DIFF
--- a/.github/workflows/maven-thrift-deploy.yml
+++ b/.github/workflows/maven-thrift-deploy.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Install thrift
-        uses: valitydev/action-setup-thrift@v0.0.6
+        uses: valitydev/action-setup-thrift@v1.0.2
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Поднял версию, т.к она расходилась с той, что указана в `maven-thrift-build.yml` из-за чего при сборке использовался свежий thrift,  а при деплое - старый.