### PR TITLE
Retrieve commit info for shade plugin

### DIFF
--- a/.github/workflows/maven-thrift-build.yml
+++ b/.github/workflows/maven-thrift-build.yml
@@ -33,5 +33,9 @@ jobs:
           distribution: ${{ inputs.java-distribution }}
           cache: 'maven'
 
+      - name: Retrieve commit info
+        id: commit_info
+        uses: valitydev/java-workflow/.github/actions/commit-info@v3
+
       - name: Build packages
-        run: mvn -B clean verify
+        run: mvn -B clean verify -Dcommit.number=${{ env.COMMIT_NUMBER }}


### PR DESCRIPTION
Во время сборки плагину maven-shade-plugin нужна информация о коммите, сейчас ее нет, что ведет к ошибкам: https://github.com/valitydev/limiter-proto/actions/runs/15255498837/job/42902013468